### PR TITLE
link DOIs against preferred resolver

### DIFF
--- a/standard_settings.tex
+++ b/standard_settings.tex
@@ -3,7 +3,7 @@
 \setlength{\captionmargin}{40pt}
 
 % DOI settings
-\newcommand*{\doi}[1]{\href{http://dx.doi.org/#1}{doi: #1}}
+\newcommand*{\doi}[1]{\href{https://doi.org/#1}{doi: #1}}
 
 % Tabular column setting
 \usepackage{array}


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)